### PR TITLE
Bundle configuration based on omniplay classes names

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,35 +48,35 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
                 ->children()
-                ->arrayNode('gateways')
-                ->useAttributeAsKey('name')
-                ->prototype('array')
-                ->children()
-                ->scalarNode('type')
-                ->validate()
-                ->ifTrue(function($type) use ($gateways){
-                            if (empty($type)) {
-                                return true;
-                            }
+                    ->arrayNode('gateways')
+                        ->useAttributeAsKey('name')
+                        ->prototype('array')
+                            ->children()
+                                ->scalarNode('type')
+                                    ->validate()
+                                        ->ifTrue(function($type) use ($gateways){
+                                                    if (empty($type)) {
+                                                        return true;
+                                                    }
 
-                            if (!in_array($type, $gateways)) {
-                                return true;
-                            }
+                                                    if (!in_array($type, $gateways)) {
+                                                        return true;
+                                                    }
 
-                            return false;
-                        })
-                ->thenInvalid(sprintf('Unknown payment gateway selected. Valid gateways are: %s.',  implode(", ",$gateways)))
-                ->end()
-                ->end()
-                ->scalarNode('label')->cannotBeEmpty()->end()
-                ->booleanNode('mode')->defaultFalse()->end()
-                ->booleanNode('active')->defaultTrue()->end()
-                ->arrayNode('options')
-                ->prototype('scalar')
-                ->end()
-                ->end()
-                ->end()
-                ->end()
+                                                    return false;
+                                                })
+                                        ->thenInvalid(sprintf('Unknown payment gateway selected. Valid gateways are: %s.',  implode(", ",$gateways)))
+                                    ->end()
+                                ->end()
+                                ->scalarNode('label')->cannotBeEmpty()->end()
+                                ->booleanNode('mode')->defaultFalse()->end()
+                                ->booleanNode('active')->defaultTrue()->end()
+                                ->arrayNode('options')
+                                    ->prototype('scalar')
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
                 ->end()
         ;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,7 +46,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $builder  = new TreeBuilder();
-        $rootNode = $builder->root('sylius_payments');
+        $rootNode = $builder->root('sylius_omnipay');
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,8 +13,7 @@ namespace Sylius\Bundle\OmnipayBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Omnipay\Common\GatewayFactory as OmnipayGatewayFactory;
-use Omnipay\Common\Helper as OmnipayHelper;
+use Omnipay\Common\GatewayFactory;
 
 /**
  * This class contains the configuration information for the bundle.
@@ -23,19 +22,6 @@ use Omnipay\Common\Helper as OmnipayHelper;
  */
 class Configuration implements ConfigurationInterface
 {
-
-    /**
-     * List of known gateways.
-     *
-     * @var array
-     */
-    private $gateways;
-
-    public function __construct()
-    {
-        $this->gateways = OmnipayGatewayFactory::find();
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -44,7 +30,7 @@ class Configuration implements ConfigurationInterface
         $builder = new TreeBuilder();
         $rootNode = $builder->root('sylius_omnipay');
 
-        $gateways = $this->getGateways();
+        $gateways = GatewayFactory::find();
 
         $rootNode
                 ->children()
@@ -82,10 +68,4 @@ class Configuration implements ConfigurationInterface
 
         return $builder;
     }
-
-    public function getGateways()
-    {
-        return $this->gateways;
-    }
-
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,6 +13,8 @@ namespace Sylius\Bundle\OmnipayBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Omnipay\Common\GatewayFactory as OmnipayGatewayFactory;
+use Omnipay\Common\Helper as OmnipayHelper;
 
 /**
  * This class contains the configuration information for the bundle.
@@ -21,118 +23,69 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+
     /**
      * List of known gateways.
      *
      * @var array
      */
-    public static $gateways = array(
-        'authorizenet',
-        'cardsafe',
-        'dummy',
-        'gocardless',
-        'paypal',
-        'payflow',
-        'paymentexpress',
-        'pin',
-        'stripe',
-        'twocheckout',
-        'worldpay',
-    );
+    private $gateways;
+
+    public function __construct()
+    {
+        $this->gateways = OmnipayGatewayFactory::find();
+    }
 
     /**
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
-        $builder  = new TreeBuilder();
+        $builder = new TreeBuilder();
         $rootNode = $builder->root('sylius_omnipay');
 
+        $gateways = $this->getGateways();
+
         $rootNode
-            ->children()
+                ->children()
                 ->arrayNode('gateways')
-                    ->useAttributeAsKey('name')
-                    ->prototype('array')
-                        ->children()
-                            ->scalarNode('type')
-                                ->validate()
-                                    ->ifTrue(function($type) {
-                                        if (empty($type)) {
-                                            return true;
-                                        }
+                ->useAttributeAsKey('name')
+                ->prototype('array')
+                ->children()
+                ->scalarNode('type')
+                ->validate()
+                ->ifTrue(function($type) use ($gateways){
+                            if (empty($type)) {
+                                return true;
+                            }
 
-                                        if (!in_array(strtolower($type), self::$gateways)) {
-                                            return true;
-                                        }
+                            if (!in_array($type, $gateways)) {
+                                return true;
+                            }
 
-                                        return false;
-                                    })
-                                    ->thenInvalid('Unknown payment gateway selected "%s".')
-                                ->end()
-                                ->validate()
-                                    ->ifTrue(function($type) {
-                                        return true; // fake =)
-                                    })
-                                    ->then(function($type) {
-                                        return $this->translateTypeName($type);
-                                    })
-                                ->end()
-                            ->end()
-                            ->scalarNode('label')->cannotBeEmpty()->end()
-                            ->booleanNode('mode')->defaultFalse()->end()
-                            ->booleanNode('active')->defaultTrue()->end()
-                            ->arrayNode('options')
-                                ->prototype('scalar')
-                            ->end()
-                        ->end()
-                    ->end()
+                            return false;
+                        })
+                ->thenInvalid(sprintf('Unknown payment gateway selected. Valid gateways are: %s.',  implode(", ",$gateways)))
                 ->end()
-            ->end()
+                ->end()
+                ->scalarNode('label')->cannotBeEmpty()->end()
+                ->booleanNode('mode')->defaultFalse()->end()
+                ->booleanNode('active')->defaultTrue()->end()
+                ->arrayNode('options')
+                ->prototype('scalar')
+                ->end()
+                ->end()
+                ->end()
+                ->end()
+                ->end()
         ;
 
         return $builder;
     }
 
-    private function translateTypeName($type)
+    public function getGateways()
     {
-        switch ($type) {
-            case 'authorizenet':
-                $class = 'AuthorizeNet';
-                break;
-            case 'cardsafe':
-                $class = 'CardSafe';
-                break;
-            case 'dummy':
-                $class = 'Dummy';
-                break;
-            case 'gocardless':
-                $class = 'GoCardless';
-                break;
-            case 'paypal':
-                $class = 'PayPal';
-                break;
-            case 'payflow':
-                $class = 'Payflow';
-                break;
-            case 'paymentexpress':
-                $class = 'PaymentExpress';
-                break;
-            case 'pin':
-                $class = 'Pin';
-                break;
-            case 'stripe':
-                $class = 'Stripe';
-                break;
-            case 'twocheckout':
-                $class = 'TwoCheckout';
-                break;
-            case 'worldpay':
-                $class = 'WorldPay';
-                break;
-            default:
-                throw new \InvalidArgumentException(sprintf('Unknown payment gateway selected "%s".', $type));
-        }
-
-        return $class;
+        return $this->gateways;
     }
+
 }

--- a/DependencyInjection/SyliusOmnipayExtension.php
+++ b/DependencyInjection/SyliusOmnipayExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Omnipay\Common\Helper as OmnipayHelper;
+use Omnipay\Common\Helper;
 
 /**
  * Payments dependency injection extension.
@@ -26,7 +26,6 @@ use Omnipay\Common\Helper as OmnipayHelper;
  */
 class SyliusOmnipayExtension extends Extension
 {
-
     /**
      * Registered gateways with name and label.
      *
@@ -74,7 +73,7 @@ class SyliusOmnipayExtension extends Extension
     public function createGatewayService(ContainerBuilder $container, $name, array $parameters)
     {
         $type = $parameters['type'];
-        $class = trim(OmnipayHelper::getGatewayClassName($type), "\\");
+        $class = trim(Helper::getGatewayClassName($type), "\\");
 
         $definition = new Definition($class);
         $definition


### PR DESCRIPTION
Modifies bundle configuration:
1. Configuration root is sylius_omnipay, replacing old sylius_payments
2. Available Gateways are retrieved using Omipay GatewayFactory::find
3. In configuration a valid gateway type must be provided, it has to match Omnipay name. Example

```
sylius_omnipay:
      gateways:
        paypal:
          type: PayPal_Express
          label: Paypal Express
        sagepay:
          type: SagePay_Direct
          label: Sagepay Direct
```

I am starting to work with this bundle, hope this modification won't break anything!
