### PR TITLE
Credit card types branch

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('type')
                                     ->validate()
-                                        ->ifTrue(function($type) use ($gateways){
+                                        ->ifTrue(function($type) use ($gateways) {
                                                     if (empty($type)) {
                                                         return true;
                                                     }
@@ -61,9 +61,9 @@ class Configuration implements ConfigurationInterface
                                 ->booleanNode('mode')->defaultFalse()->end()
                                 ->booleanNode('active')->defaultTrue()->end()
                                 ->arrayNode('cc_types')
-            						->prototype('scalar')
-            							->validate()
-                                        	->ifTrue(function($ccType) use ($brands){
+                                    ->prototype('scalar')
+                                        ->validate()
+                                            ->ifTrue(function($ccType) use ($ccTypes) {
                                                     if (empty($ccType)) {
                                                         return true;
                                                     }
@@ -74,10 +74,10 @@ class Configuration implements ConfigurationInterface
 
                                                     return false;
                                                 })
-                                        	->thenInvalid(sprintf('Unknown credit card type selected. Valid credit card types are: %s.',  implode(", ",$ccTypes)))
-                                    	->end()
-            						->end()
-        						->end()
+                                            ->thenInvalid(sprintf('Unknown credit card type selected. Valid credit card types are: %s.',  implode(", ",$ccTypes)))
+                                        ->end()
+                                    ->end()
+                                ->end()
                                 ->arrayNode('options')
                                     ->prototype('scalar')
                                 ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,7 +33,8 @@ class Configuration implements ConfigurationInterface
         $rootNode = $builder->root('sylius_omnipay');
 
         $gateways = GatewayFactory::find();
-        $ccTypes = array_keys(new CreditCard()->getSupportedBrands());
+        $omnipayCc = new CreditCard();
+        $ccTypes = array_keys($omnipayCc->getSupportedBrands());
 
         $rootNode
                 ->children()


### PR DESCRIPTION
Adds credit card types to gateway configuration. In the event an Omnipay gateway is chosen as the payment method, these can be used to supply the choices in the `type` field of a credit card form.
