### PR TITLE
add credit card interface for mapping to omnipay format

### DIFF
--- a/Model/CreditCardInterface.php
+++ b/Model/CreditCardInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\OmnipayBundle\Model;
+
+/**
+ * Credit Card interface.
+ *
+ * @author Dylan Johnson <eponymi.dev@gmail.com>
+ */
+ interface CreditCardInterface
+{
+    /**
+     * Map a credit card model's properties to an array with Omnipay
+     * property names.
+     *
+     * @return array
+     */
+    public function mapToOmnipay(array $map);
+}

--- a/Model/CreditCardInterface.php
+++ b/Model/CreditCardInterface.php
@@ -19,10 +19,10 @@ namespace Sylius\Bundle\OmnipayBundle\Model;
  interface CreditCardInterface
 {
     /**
-     * Map a credit card model's properties to an array with Omnipay
-     * property names.
+     * Transform any credit card model into an array matching Omnipay
+     * format and naming conventions.
      *
      * @return array
      */
-    public function transformModel(array $map);
+    public function transformToOmnipay(array $map);
 }

--- a/Model/CreditCardInterface.php
+++ b/Model/CreditCardInterface.php
@@ -24,5 +24,5 @@ namespace Sylius\Bundle\OmnipayBundle\Model;
      *
      * @return array
      */
-    public function mapToOmnipay(array $map);
+    public function transformModel(array $map);
 }


### PR DESCRIPTION
Just a simple interface class that credit card entity's can implement so they have a method for mapping to Omnipay format before submitting to a gateway. 

I considered putting constants for all of the Omnipay properties, or writing a "mapper" class that implemented this interface and had a check for Omnipay methods named "set[whateverProperty]" but those both seemed too heavy.

This will just act as a simple reminder to implement a mapper to Omnipay format and supply the convenience method for doing that mapping.
