### PR TITLE
Allow fully qualified classnames for gateway type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ class Configuration implements ConfigurationInterface
                                                         return true;
                                                     }
 
-                                                    if (!in_array($type, $gateways)) {
+                                                    if (0 !== strpos($type, '\\') && !in_array($type, $gateways)) {
                                                         return true;
                                                     }
 


### PR DESCRIPTION
This enables support for fully qualified classnames as gateways. It's already supported by the DependencyInjectionExtension and the Omnipay Helper.
